### PR TITLE
feat: add optional context parameter for Docker build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Desired architechture for your docker image'
     default: 'linux/amd64'
     required: false
+  context:
+    description: 'Docker build context path'
+    required: false
+    default: '.'
 
 runs:
   using: composite
@@ -68,7 +72,7 @@ runs:
     - name: Build Docker - ${{ inputs.service }}
       uses: docker/build-push-action@v6
       with:
-        context: .
+        context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.service }}:${{ inputs.version }}
         build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
## Summary
This PR adds an optional `context` parameter to the build-docker action to allow customization of the Docker build context path.

## Changes
- Added new `context` input parameter with default value '.' to maintain backward compatibility
- Updated the docker/build-push-action step to use `inputs.context` instead of hardcoded '.'

## Use Case
This enables building Docker images from subdirectories. For example:
```yaml
- uses: cleartax/build-docker@main
  with:
    context: beta9
    dockerfile: beta9/docker/Dockerfile.gateway
    # ... other params
```

## Testing
- Maintains backward compatibility - existing workflows continue to work with default context '.'
- New workflows can specify custom context paths as needed

## Related
This is needed for the clarity-code-execution-sandbox release workflow to build Beta9 Docker images correctly.