### PR TITLE
feat: Add target and additional_tags parameters for multi-stage builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,14 @@ inputs:
     description: 'Docker build context path'
     required: false
     default: '.'
+  target:
+    description: 'Docker build target stage (for multi-stage builds)'
+    required: false
+    default: ''
+  additional_tags:
+    description: 'Additional tags to push (newline-separated)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -74,8 +82,11 @@ runs:
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
-        tags: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.service }}:${{ inputs.version }}
+        tags: |
+          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.service }}:${{ inputs.version }}
+          ${{ inputs.additional_tags }}
         build-args: ${{ inputs.build_args }}
+        target: ${{ inputs.target }}
         push: true
         cache-from: type=gha, scope=${{ github.workflow }}
         cache-to: type=gha, mode=max, scope=${{ github.workflow }}


### PR DESCRIPTION
- Add target parameter to support Docker multi-stage builds
- Add additional_tags parameter to push multiple tags (e.g., py310-latest)
- Enables building Python version-specific runner images

## Summary & Purpose
Briefly summarize the changes and link any related issues (e.g., Fixes #123)

## Type of Change
Mark one or more: Bug, Feature, Config, Index, Refactor, Docs, Other


## Testing Done
Briefly describe how you tested these changes.

---

## Pre-Merge Checklist
**Verify and check all applicable boxes.**

- [ ] <!-- Optional --> **Config Changes:** Any in this PR?
  - [ ] **If YES:** Updated in Vault?

- [ ] <!-- Optional --> **Index Changes:** New or updated indexes?
  - [ ] **If YES:** Applied to target environment(s)?

---

- [ ] **Author's Confirmation:** I have reviewed and completed the above checklist.

---
Optional: Any additional notes for reviewers.
