### PR TITLE
fix: Prepend ECR registry to additional_tags for proper image push

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         file: ${{ inputs.dockerfile }}
         tags: |
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.service }}:${{ inputs.version }}
-          ${{ inputs.additional_tags }}
+          ${{ inputs.additional_tags != '' && format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, inputs.service, inputs.additional_tags) || '' }}
         build-args: ${{ inputs.build_args }}
         target: ${{ inputs.target }}
         push: true


### PR DESCRIPTION
## Problem

When `additional_tags` parameter is used (e.g., `py310-latest`), the action tries to push to Docker Hub instead of ECR because the tag doesn't include the ECR registry prefix.

This causes errors like:
```
401 Unauthorized: access token has insufficient scopes
```

## Solution

Update line 87 in action.yml to prepend the ECR registry path to additional_tags:

```yaml
${{ inputs.additional_tags != '' && format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, inputs.service, inputs.additional_tags) || '' }}
```

Now additional tags like `py310-latest` will become:
```
<account-id>.dkr.ecr.ap-south-1.amazonaws.com/clarity-code-sandbox-runner:py310-latest
```

## Testing

This fix enables the multi-Python-version runner builds in the clarity-code-execution-sandbox release workflow.